### PR TITLE
Support Docker secrets for PostgreSQL password

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ services:
     read_only: true
     environment:
       TZ: "Europe/Zurich"
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       # make a full and compressed database backup each day at 03:00
       POSTGRES_BACKUP_SCHEDULE: "0 3 * * *"
     ports:
@@ -63,6 +63,10 @@ services:
       - "/postgres/run:uid=1000,gid=1000"
       - "/postgres/log:uid=1000,gid=1000"
     restart: "always"
+
+secrets:
+  postgres_password:
+    file: /secrets/postgres_password
 
 volumes:
   postgres.etc:

--- a/rootfs/usr/local/bin/entrypoint.sh
+++ b/rootfs/usr/local/bin/entrypoint.sh
@@ -1,7 +1,18 @@
 #!/bin/ash
   if [ -z "$(ls -A ${APP_ROOT}/var)" ]; then
     eleven log info "creating new database"
-    initdb --username=postgres --pwfile=<(printf "%s\n" "${POSTGRES_PASSWORD}") --pgdata ${APP_ROOT}/var &>/dev/null
+
+    # Determine password
+    if [ -n "${POSTGRES_PASSWORD_FILE:-}" ] && [ -f "$POSTGRES_PASSWORD_FILE" ]; then
+        DB_PASSWORD="$(cat "$POSTGRES_PASSWORD_FILE")"
+    elif [ -n "${POSTGRES_PASSWORD:-}" ]; then
+        DB_PASSWORD="$POSTGRES_PASSWORD"
+    else
+        eleven log error "No POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE provided"
+        exit 1
+    fi
+
+    initdb --username=postgres --pwfile=<(printf "%s\n" "$DB_PASSWORD") --pgdata "${APP_ROOT}/var" &>/dev/null
     ln -sf ${APP_ROOT}/etc/default.conf ${APP_ROOT}/var/postgresql.conf
   else
     eleven log info "loading existing database"


### PR DESCRIPTION
Code changes to address #7 

This change allows the postgresql password to be read from a file instead of just from the environment variable.